### PR TITLE
initial factorisation of dns-discovery service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ COPY conf/supervisord.conf /etc/supervisor.d/docker-gen.ini
 COPY entrypoint.sh /opt/entrypoint.sh
 
 # Default IP for Drude
-ENV DRUDE_IP '192.168.10.10'
+ENV DNS_IP '192.168.10.10'
+ENV DNS_ZONE 'localzone'
 ENV LOG_QUERIES false
 ENV DOCKER_HOST unix:///var/run/docker.sock
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,12 +3,12 @@ set -e
 
 # Default command (assuming container start)
 if [ "$1" = 'supervisord' ]; then
-	# Drude IP config for dnsmasq
-	touch /etc/dnsmasq.d/drude.conf
-	# Resolve *.drude to $DRUDE_IP
-	echo "address=/drude/${DRUDE_IP}" >> /etc/dnsmasq.d/drude.conf
-	# Reverse resolution of $DRUDE_IP to 'drude'
-	echo $DRUDE_IP | awk -F . '{print "ptr-record="$4"."$3"."$2"."$1".in-addr.arpa,drude"}' >> /etc/dnsmasq.d/drude.conf
+	# $DNS_ZONE IP config for dnsmasq
+	touch /etc/dnsmasq.d/${DNS_ZONE}.conf
+	# Resolve *.$DNS_ZONE to $DNS_IP
+	echo "address=/${DNS_ZONE}/${DNS_IP}" >> /etc/dnsmasq.d/${DNS_ZONE}.conf
+	# Reverse resolution of $DNS_IP to ${DNS_ZONE}
+	echo $DNS_IP | awk -v dzone=${DNS_ZONE} -F . '{print "ptr-record="$4"."$3"."$2"."$1".in-addr.arpa,"dzone}' >> /etc/dnsmasq.d/${DNS_ZONE}.conf
 	
 	# Turn query loggin on
 	if [ "$LOG_QUERIES" = true ]; then


### PR DESCRIPTION
this commit allows to use 
DNS_ZONE and DNS_IP as vars to have a fully dynamic wildcard DNS regarding what ever dns zone you want to use and/or ip adress of your boot2docker instance